### PR TITLE
feat: Implement hide and show game functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,9 @@ function App() { // Removed : JSX.Element return type
     const [filterMaxPrice, setFilterMaxPrice] = useState<string>('');
     const [hideNoPrice, setHideNoPrice] = useState<boolean>(false);
 
+    const [hiddenGameTitles, setHiddenGameTitles] = useState<string[]>([]);
+    const [showHidden, setShowHidden] = useState<boolean>(false);
+
     const [filterDiscountPercent, setFilterDiscountPercent] = useState<string>('0');
     const [filterTitle, setFilterTitle] = useState<string>('');
     const [filterPriceChange, setFilterPriceChange] = useState<string>('all');
@@ -27,6 +30,34 @@ function App() { // Removed : JSX.Element return type
 
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const storedHiddenGames = localStorage.getItem('hiddenGameTitles');
+        if (storedHiddenGames) {
+            try {
+                const parsedHiddenGames = JSON.parse(storedHiddenGames);
+                if (Array.isArray(parsedHiddenGames)) {
+                    setHiddenGameTitles(parsedHiddenGames);
+                } else {
+                    console.warn("Stored hiddenGameTitles is not an array:", parsedHiddenGames);
+                    setHiddenGameTitles([]); // Fallback to empty array
+                }
+            } catch (e) {
+                console.error("Failed to parse hiddenGameTitles from localStorage:", e);
+                setHiddenGameTitles([]); // Fallback to empty array on error
+            }
+        }
+    }, []); // Runs once on mount
+
+    const toggleHideGame = (gameTitle: string) => {
+        setHiddenGameTitles(prevHidden => {
+            const newHiddenGames = prevHidden.includes(gameTitle)
+                ? prevHidden.filter(title => title !== gameTitle)
+                : [...prevHidden, gameTitle];
+            localStorage.setItem('hiddenGameTitles', JSON.stringify(newHiddenGames));
+            return newHiddenGames;
+        });
+    };
 
     useEffect(() => {
         setIsLoading(true);
@@ -70,6 +101,10 @@ function App() { // Removed : JSX.Element return type
         }
 
         let workingGames: Game[] = [...allGames];
+
+        if (!showHidden) {
+            workingGames = workingGames.filter(game => !hiddenGameTitles.includes(game.titulo));
+        }
 
         const minPrice = filterMinPrice === '' ? NaN : parseFloat(filterMinPrice);
         const maxPrice = filterMaxPrice === '' ? NaN : parseFloat(filterMaxPrice);
@@ -132,7 +167,7 @@ function App() { // Removed : JSX.Element return type
         }
         setDisplayedGames(workingGames);
         setVisibleCount(50);
-    }, [allGames, isLoading, sortType, filterMinPrice, filterMaxPrice, filterDiscountPercent, filterTitle, hideNoPrice, filterPriceChange]);
+    }, [allGames, isLoading, sortType, filterMinPrice, filterMaxPrice, filterDiscountPercent, filterTitle, hideNoPrice, filterPriceChange, hiddenGameTitles, showHidden]);
 
     useEffect(() => {
         applyFiltersAndSort();
@@ -286,6 +321,13 @@ function App() { // Removed : JSX.Element return type
                 <div className="clear-filters-wrapper">
                      <button id="clear-filter-button" onClick={handleClearFilters}>Limpiar Filtros</button>
                 </div>
+
+                {/* Botón para mostrar/ocultar juegos ocultos */}
+                <div className="show-hidden-toggle-wrapper">
+                    <button onClick={() => setShowHidden(!showHidden)} className="toggle-hidden-btn">
+                        {showHidden ? "Ocultar Juegos Ocultos" : "Mostrar Juegos Ocultos"} ({hiddenGameTitles.length})
+                    </button>
+                </div>
             </div>
             
             {/* Contador de juegos */}
@@ -293,7 +335,10 @@ function App() { // Removed : JSX.Element return type
                 Mostrando {Math.min(visibleCount, displayedGames.length)} de {displayedGames.length} juegos
             </div>
             
-            <GameList games={displayedGames.slice(0, visibleCount)} />
+            <GameList
+                games={displayedGames.slice(0, visibleCount)}
+                onHideGame={toggleHideGame}
+            />
             
             {/* Carga de más juegos */}
             {isLoadingMore && (

--- a/src/components/GameItem.tsx
+++ b/src/components/GameItem.tsx
@@ -5,9 +5,10 @@ interface GameItemProps {
   game: Game;
   isSelected: boolean;
   onSelectToggle: (game: Game) => void;
+  onHideGame: (title: string) => void; // New prop
 }
 
-const GameItem: React.FC<GameItemProps> = ({ game, isSelected, onSelectToggle }) => {
+const GameItem: React.FC<GameItemProps> = ({ game, isSelected, onSelectToggle, onHideGame }) => {
     const isValidImageUrl = game.imagen_url && game.imagen_url !== "Imagen no encontrada" && game.imagen_url.startsWith('http');
 
     let discountColorClass = '';
@@ -46,6 +47,10 @@ const GameItem: React.FC<GameItemProps> = ({ game, isSelected, onSelectToggle })
                     aria-label={`Seleccionar ${game.titulo}`}
                 />
             </div>
+            {/* Add the new button here */}
+            <button onClick={() => onHideGame(game.titulo)} className="hide-game-btn">
+                Ocultar Juego
+            </button>
             
             {isValidImageUrl && game.imagen_url ? ( // Added check for game.imagen_url to satisfy TS strict null checks potentially
                 <img 

--- a/src/components/GameList.tsx
+++ b/src/components/GameList.tsx
@@ -5,9 +5,10 @@ import { Game } from '../types'; // Import Game type
 
 interface GameListProps {
   games: Game[];
+  onHideGame: (title: string) => void; // New prop
 }
 
-const GameList: React.FC<GameListProps> = ({ games }) => {
+const GameList: React.FC<GameListProps> = ({ games, onHideGame }) => {
     const [selectedGames, setSelectedGames] = useState<Game[]>([]);
     const [showShareModal, setShowShareModal] = useState<boolean>(false);
     
@@ -35,6 +36,7 @@ const GameList: React.FC<GameListProps> = ({ games }) => {
                         game={game} 
                         isSelected={selectedGames.some(g => g.id === game.id || g.link === game.link)}
                         onSelectToggle={handleSelectToggle}
+                        onHideGame={onHideGame} // Pass the prop down
                     />
                 ))}
             </ul>


### PR DESCRIPTION
This commit introduces the ability for you to hide games from your view and later show them if desired.

Key changes:
- Added an "Ocultar Juego" (Hide Game) button to each game item.
- Clicking this button adds the game's title to a list in localStorage.
- Hidden games are excluded from the main game list and search results by default.
- Added a "Mostrar/Ocultar Juegos Ocultos" (Show/Hide Hidden Games) button.
- This button toggles the visibility of hidden games in the list.
- The list of hidden game titles is persisted in localStorage.
- GameItem, GameList, and App components were updated to support this feature.