### PR TITLE
feat: Implement bulk hide for selected games and filter-style toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,9 @@ function App() { // Removed : JSX.Element return type
     const [filterMaxPrice, setFilterMaxPrice] = useState<string>('');
     const [hideNoPrice, setHideNoPrice] = useState<boolean>(false);
 
+    const [hiddenGameTitles, setHiddenGameTitles] = useState<string[]>([]);
+    const [showHidden, setShowHidden] = useState<boolean>(false);
+
     const [filterDiscountPercent, setFilterDiscountPercent] = useState<string>('0');
     const [filterTitle, setFilterTitle] = useState<string>('');
     const [filterPriceChange, setFilterPriceChange] = useState<string>('all');
@@ -27,6 +30,34 @@ function App() { // Removed : JSX.Element return type
 
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const storedHiddenGames = localStorage.getItem('hiddenGameTitles');
+        if (storedHiddenGames) {
+            try {
+                const parsedHiddenGames = JSON.parse(storedHiddenGames);
+                if (Array.isArray(parsedHiddenGames)) {
+                    setHiddenGameTitles(parsedHiddenGames);
+                } else {
+                    console.warn("Stored hiddenGameTitles is not an array:", parsedHiddenGames);
+                    setHiddenGameTitles([]); // Fallback to empty array
+                }
+            } catch (e) {
+                console.error("Failed to parse hiddenGameTitles from localStorage:", e);
+                setHiddenGameTitles([]); // Fallback to empty array on error
+            }
+        }
+    }, []); // Runs once on mount
+
+    const handleHideSelectedGames = (gamesToHide: Game[]) => {
+        const titlesToHide = gamesToHide.map(game => game.titulo);
+        setHiddenGameTitles(prevHiddenTitles => {
+            const newHiddenTitlesSet = new Set([...prevHiddenTitles, ...titlesToHide]);
+            const newHiddenTitlesArray = Array.from(newHiddenTitlesSet);
+            localStorage.setItem('hiddenGameTitles', JSON.stringify(newHiddenTitlesArray));
+            return newHiddenTitlesArray;
+        });
+    };
 
     useEffect(() => {
         setIsLoading(true);
@@ -70,6 +101,10 @@ function App() { // Removed : JSX.Element return type
         }
 
         let workingGames: Game[] = [...allGames];
+
+        if (!showHidden) {
+            workingGames = workingGames.filter(game => !hiddenGameTitles.includes(game.titulo));
+        }
 
         const minPrice = filterMinPrice === '' ? NaN : parseFloat(filterMinPrice);
         const maxPrice = filterMaxPrice === '' ? NaN : parseFloat(filterMaxPrice);
@@ -132,7 +167,7 @@ function App() { // Removed : JSX.Element return type
         }
         setDisplayedGames(workingGames);
         setVisibleCount(50);
-    }, [allGames, isLoading, sortType, filterMinPrice, filterMaxPrice, filterDiscountPercent, filterTitle, hideNoPrice, filterPriceChange]);
+    }, [allGames, isLoading, sortType, filterMinPrice, filterMaxPrice, filterDiscountPercent, filterTitle, hideNoPrice, filterPriceChange, hiddenGameTitles, showHidden]);
 
     useEffect(() => {
         applyFiltersAndSort();
@@ -286,6 +321,18 @@ function App() { // Removed : JSX.Element return type
                 <div className="clear-filters-wrapper">
                      <button id="clear-filter-button" onClick={handleClearFilters}>Limpiar Filtros</button>
                 </div>
+
+                {/* Checkbox para mostrar juegos ocultos */}
+                <div className="filter-checkbox-control">
+                    <label>
+                        <input
+                            type="checkbox"
+                            checked={showHidden}
+                            onChange={(e) => setShowHidden(e.target.checked)}
+                        />
+                        Mostrar juegos ocultos ({hiddenGameTitles.length})
+                    </label>
+                </div>
             </div>
             
             {/* Contador de juegos */}
@@ -293,7 +340,10 @@ function App() { // Removed : JSX.Element return type
                 Mostrando {Math.min(visibleCount, displayedGames.length)} de {displayedGames.length} juegos
             </div>
             
-            <GameList games={displayedGames.slice(0, visibleCount)} />
+            <GameList
+                games={displayedGames.slice(0, visibleCount)}
+                onHideSelectedGames={handleHideSelectedGames}
+            />
             
             {/* Carga de más juegos */}
             {isLoadingMore && (

--- a/src/components/GameList.tsx
+++ b/src/components/GameList.tsx
@@ -5,9 +5,10 @@ import { Game } from '../types'; // Import Game type
 
 interface GameListProps {
   games: Game[];
+  onHideSelectedGames: (games: Game[]) => void; // New prop
 }
 
-const GameList: React.FC<GameListProps> = ({ games }) => {
+const GameList: React.FC<GameListProps> = ({ games, onHideSelectedGames }) => {
     const [selectedGames, setSelectedGames] = useState<Game[]>([]);
     const [showShareModal, setShowShareModal] = useState<boolean>(false);
     
@@ -20,6 +21,11 @@ const GameList: React.FC<GameListProps> = ({ games }) => {
                 return [...prevSelectedGames, game];
             }
         });
+    };
+
+    const handleHideSelectedClick = () => {
+        onHideSelectedGames(selectedGames);
+        setSelectedGames([]); // Clear selection after hiding
     };
 
     if (!games || games.length === 0) {
@@ -35,6 +41,7 @@ const GameList: React.FC<GameListProps> = ({ games }) => {
                         game={game} 
                         isSelected={selectedGames.some(g => g.id === game.id || g.link === game.link)}
                         onSelectToggle={handleSelectToggle}
+                        // onHideGame prop removed from GameItem
                     />
                 ))}
             </ul>
@@ -47,6 +54,14 @@ const GameList: React.FC<GameListProps> = ({ games }) => {
                         title="Compartir juegos seleccionados"
                     >
                         Compartir ({selectedGames.length})
+                    </button>
+                    {/* New Button */}
+                    <button
+                        className="hide-selected-btn"
+                        onClick={handleHideSelectedClick}
+                        title="Ocultar juegos seleccionados"
+                    >
+                        Ocultar Seleccionados ({selectedGames.length})
                     </button>
                 </div>
             )}


### PR DESCRIPTION
This commit refines the game hiding functionality based on your feedback. Games can now be hidden in bulk when selected, and the control to show/hide hidden games is integrated into the main filter panel.

Key changes:
- Removed the per-item "Ocultar Juego" button.
- Added an "Ocultar Seleccionados (X)" button that appears in the floating action panel when one or more games are selected. Clicking this button hides all currently selected games.
- Game titles to be hidden are stored in localStorage.
- Replaced the previous standalone "Mostrar/Ocultar Juegos Ocultos" button with a checkbox integrated into the filter controls section. This checkbox, labeled "Mostrar juegos ocultos (X)", toggles the visibility of hidden games in the main list and displays the current count of hidden games.
- Updated App.tsx, GameList.tsx, and reverted GameItem.tsx to support this revised functionality.